### PR TITLE
Create a public "Scanner" type that allows the Field into to be used externally

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,42 @@ func (e MapTagDecoder) DecodeField(info Field) (interface{}, error) {
 }
 ```
 
+If you wish to use the Field info (names, tags, type etc) elsewhere or if you
+have a large number of the same type if items to decode then creating a scanner
+object is the way to go. This also makes use of Go 1.18+'s generics so if you
+pass the wrong type of object in it is a compile error.
+
+
+```golang
+decoder := structscanner.FuncTagDecoder(...)
+
+type User struct {
+	Name    string `map:"name"`
+	HomeDir string `map:"home"`
+}
+
+scanner, err := structscanner.New[User](decoder)
+if err != nil {
+	panic(err)
+}
+
+for _, field := range scanner.Fields {
+	fmt.Println("Field %q has tags %v", field.Name, field.Tags)
+}
+```
+
+Note that structscanner caches the type reflection so that calling
+`structscanner.Decode()` many times will be quiet efficient (i.e. reflection on
+the struct will only be performed once per program invocation). However if you
+would like there is a `Decode` method on the `Scanner` type:
+
+```golang
+for _, row := range getData() {
+	var user User;
+	err = scanner.Decode(&user)
+}
+```
+
 ## License
 
 This project was put into public domain, which means you can copy, use and modify

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -450,6 +450,23 @@ func TestDecode(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("simple generic test", func(t *testing.T) {
+		decoder := ss.FuncTagDecoder(func(field ss.Field) (interface{}, error) {
+			return "fake-value-for-string", nil
+		})
+
+		type Output struct {
+			Attr1 string `env:"attr1"`
+		}
+		var output Output
+		scanner, err := ss.New[Output](decoder)
+		tt.AssertNoErr(t, err)
+
+		err = scanner.Decode(&output)
+		tt.AssertNoErr(t, err)
+		tt.AssertEqual(t, output.Attr1, "fake-value-for-string")
+	})
 }
 
 func intPtr(i int) *int {


### PR DESCRIPTION
For type safety on each call we use go-generics on this version to make it a compile error to pass the wrong type.

The existing `interface{}` version remains unchanged/altered.

Closes #3
