### PR TITLE
Ensure that errors returned from decoder correctly wrap the actual error

### DIFF
--- a/internal/testtools/assert.go
+++ b/internal/testtools/assert.go
@@ -15,6 +15,12 @@ func AssertEqual(t *testing.T, got interface{}, expected interface{}, msg ...int
 	require.Equal(t, expected, got, msg...)
 }
 
+// True asserts that the specified value is true
+// and fail the test with an appropriate error message if they don't match.
+func AssertTrue(t *testing.T, value bool, msg ...interface{}) {
+	require.True(t, value, msg...)
+}
+
 // AssertNotEqual will compare the got argument with the expected argument
 // and fail the test with an appropriate error message if they match.
 func AssertNotEqual(t *testing.T, got interface{}, expected interface{}, msg ...interface{}) {

--- a/scanner.go
+++ b/scanner.go
@@ -53,7 +53,7 @@ func Decode(targetStruct interface{}, decoder TagDecoder) error {
 	for _, field := range fields {
 		rawValue, err := decoder.DecodeField(field)
 		if err != nil {
-			return fmt.Errorf("error decoding field %v: %s", t.Field(field.idx), err)
+			return fmt.Errorf("error decoding field %v: %w", t.Field(field.idx), err)
 		}
 
 		if rawValue == nil {
@@ -105,7 +105,7 @@ func Decode(targetStruct interface{}, decoder TagDecoder) error {
 
 			err := Decode(fieldAddr.Interface(), decoder)
 			if err != nil {
-				return fmt.Errorf("error decoding nested field '%s': %s", t.Field(field.idx).Name, err)
+				return fmt.Errorf("error decoding nested field %q: %w", t.Field(field.idx).Name, err)
 			}
 			continue
 		}

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	ss "github.com/vingarcia/structscanner"
 	tt "github.com/vingarcia/structscanner/internal/testtools"
 )
@@ -466,8 +465,8 @@ func TestDecode(t *testing.T) {
 			}{}, decoder)
 
 			var parseErr *strconv.NumError
-			require.True(t, errors.As(err, &parseErr), "error %#v should wrap %T", err, parseErr)
-			require.Equal(t, parseErr.Err, strconv.ErrSyntax)
+			tt.AssertTrue(t, errors.As(err, &parseErr), "error %#v should wrap %T", err, parseErr)
+			tt.AssertEqual(t, parseErr.Err, strconv.ErrSyntax)
 		})
 
 		t.Run("wrap error from nested Decoder", func(t *testing.T) {
@@ -486,13 +485,12 @@ func TestDecode(t *testing.T) {
 			}
 			err := ss.Decode(&Outer{}, decoder)
 
-			require.Error(t, err)
 			// Sanity check: the outer error _does_ contain the string we don't want to see in the wrapped error
-			require.Contains(t, err.Error(), "error decoding nested field")
+			tt.AssertErrContains(t, err, "error decoding nested field")
 
 			var parseErr *strconv.NumError
-			require.True(t, errors.As(err, &parseErr), "error %#v should wrap %T", err, parseErr)
-			require.Equal(t, parseErr.Err, strconv.ErrSyntax)
+			tt.AssertTrue(t, errors.As(err, &parseErr), "error %#v should wrap %T", err, parseErr)
+			tt.AssertEqual(t, parseErr.Err, strconv.ErrSyntax)
 		})
 
 		t.Run("wrap error from slice conversion", func(t *testing.T) {
@@ -504,14 +502,12 @@ func TestDecode(t *testing.T) {
 				A []int `a:""`
 			}{}, decoder)
 
-			require.Error(t, err)
 			// Sanity check: the outer error _does_ contain the string we don't want to see in the wrapped error
-			require.Contains(t, err.Error(), "error converting A[0]")
+			tt.AssertErrContains(t, err, "error converting A[0]")
 
 			// In this case, it should just be a wrapped sting error
 			wrapped := errors.Unwrap(err)
-			require.NotSame(t, wrapped, err)
-			require.NotContains(t, wrapped.Error(), "error converting A[0]")
+			tt.AssertNotEqual(t, wrapped, nil)
 		})
 	})
 }


### PR DESCRIPTION
Slice conversion already wrapped the error type (by using `%w` to
fmt.Errorf) but decoder error (top level or nested) didn't.

This fixes the oversight and adds a test to ensure that all places stay
wrapped.
