### PR TITLE
Create a `GetStructInfo` function to allow people to use the field info

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,50 @@ func (e MapTagDecoder) DecodeField(info Field) (interface{}, error) {
 }
 ```
 
+If you wish to use the Field info (names, tags, type etc) elsewhere you can use the `GetStructInfo()` function.
+
+```golang
+
+type User struct {
+	Name    string `map:"name"`
+	HomeDir string `map:"home"`
+}
+
+info, err := structscanner.GetStructInfo(&User{})
+if err != nil {
+	panic(err)
+}
+
+for _, field := range info.Fields {
+	fmt.Println("Field %q has tags %v", field.Name, field.Tags)
+}
+```
+
+It is possible to pass a `reflection.Type` object to `GetStructInfo`, which is particularly useful for nested structs:
+
+```golang
+
+type Address struct {}
+type User struct {
+	Name    string `map:"name"`
+	HomeDir Address `map:"home"`
+}
+
+info, err := structscanner.GetStructInfo(&User{})
+if err != nil {
+	panic(err)
+}
+
+for _, field := range info.Fields {
+	fmt.Println("Field %q has tags %v", field.Name, field.Tags)
+	if field.Kind == reflect.Struct {
+		nestedInfo, err := structscanner.GetStructInfo(field.Type)
+		fmt.Println("Nested Field %q has %d fields", field.Name, len(nestedInfo.Fields))
+	}
+}
+```
+
+
 ## License
 
 This project was put into public domain, which means you can copy, use and modify

--- a/scanner.go
+++ b/scanner.go
@@ -59,7 +59,7 @@ func GetStructInfo(targetStruct interface{}) (si StructInfo, err error) {
 	} else {
 		_, _, si.Fields, err = getStructInfo(targetStruct)
 	}
-	return
+	return si, err
 }
 
 // Decode reads from the input decoder in order to fill the

--- a/scanner.go
+++ b/scanner.go
@@ -46,7 +46,7 @@ type StructInfo struct {
 	Fields []Field
 }
 
-// GetStructInfo will return (and cache) informatoin about the given struct.
+// GetStructInfo will return (and cache) information about the given struct.
 //
 // `targetStruct` should either be a pointer to a struct type, or a
 // reflect.Type object of the structure in question

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -452,6 +452,43 @@ func TestDecode(t *testing.T) {
 	})
 }
 
+func TestGetStructInfo(t *testing.T) {
+	type MyStruct struct {
+		A int
+	}
+
+	t.Run("should work for a struct pointer", func(t *testing.T) {
+		var s MyStruct
+		si, err := ss.GetStructInfo(&s)
+		tt.AssertNoErr(t, err)
+		tt.AssertEqual(t, len(si.Fields), 1)
+	})
+
+	t.Run("should fail for a struct", func(t *testing.T) {
+		var s MyStruct
+		_, err := ss.GetStructInfo(s)
+		tt.AssertErrContains(t, err, "struct pointer", "MyStruct")
+	})
+
+	t.Run("should work for reflect.Type", func(t *testing.T) {
+		typ := reflect.TypeOf(MyStruct{})
+		si, err := ss.GetStructInfo(typ)
+		tt.AssertNoErr(t, err)
+		tt.AssertEqual(t, len(si.Fields), 1)
+	})
+	t.Run("should work for reflect.Type of a struct pointer", func(t *testing.T) {
+		typ := reflect.TypeOf(&MyStruct{})
+		si, err := ss.GetStructInfo(typ)
+		tt.AssertNoErr(t, err)
+		tt.AssertEqual(t, len(si.Fields), 1)
+	})
+	t.Run("should fa for reflect.Type of not a struct", func(t *testing.T) {
+		typ := reflect.TypeOf(1)
+		_, err := ss.GetStructInfo(typ)
+		tt.AssertErrContains(t, err, "can only get struct info from structs", `"int"`)
+	})
+}
+
 func intPtr(i int) *int {
 	return &i
 }

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -482,7 +482,7 @@ func TestGetStructInfo(t *testing.T) {
 		tt.AssertNoErr(t, err)
 		tt.AssertEqual(t, len(si.Fields), 1)
 	})
-	t.Run("should fa for reflect.Type of not a struct", func(t *testing.T) {
+	t.Run("should fail if input type is not a kind of struct or struct pointer", func(t *testing.T) {
 		typ := reflect.TypeOf(1)
 		_, err := ss.GetStructInfo(typ)
 		tt.AssertErrContains(t, err, "can only get struct info from structs", `"int"`)


### PR DESCRIPTION
This function is designed for people to use the info about the field that this library generates internally for other uses that we thought of.

Since structures can be tested, `GetStructInfo` takes a reflect.Type so that when a field is a structure, it is possible to do `GetStructInfo(fields[i].Type)` too.

Closes #3
