### PR TITLE
Update GetStructInfo so we avoid doing unnecessary checks if the input type is cached

### DIFF
--- a/scanner.go
+++ b/scanner.go
@@ -164,10 +164,9 @@ func getStructInfo(targetStruct interface{}) (reflect.Type, reflect.Value, []Fie
 }
 
 func getStructInfoForType(ptrType reflect.Type) (reflect.Type, []Field, error) {
-	data, _ := structInfoCache.Load(ptrType)
-	info, ok := data.([]Field)
-	if ok {
-		return ptrType.Elem(), info, nil
+	data, found := structInfoCache.Load(ptrType)
+	if found {
+		return ptrType.Elem(), data.([]Field), nil
 	}
 
 	if ptrType.Kind() != reflect.Ptr {
@@ -179,7 +178,7 @@ func getStructInfoForType(ptrType reflect.Type) (reflect.Type, []Field, error) {
 		return nil, nil, fmt.Errorf("can only get struct info from structs, but got: %s", ptrType)
 	}
 
-	info = []Field{}
+	info := []Field{}
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		// If it is unexported:

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -545,7 +545,7 @@ func TestGetStructInfo(t *testing.T) {
 	t.Run("should fail if input type is not a kind of struct or struct pointer", func(t *testing.T) {
 		typ := reflect.TypeOf(1)
 		_, err := ss.GetStructInfo(typ)
-		tt.AssertErrContains(t, err, "can only get struct info from structs", `"int"`)
+		tt.AssertErrContains(t, err, "can only get struct info from structs", "int")
 	})
 }
 


### PR DESCRIPTION
Hey @ashb,

I thought about this optimization when discussing the issue you created, so I thought it would be nice to have a review from you on this PR.

What I am doing here is just changing slightly the key we use on the cache, so that we don't have to do much reflection before retrieving the cached value. This should save us a few operations on each call to GetStructInfo.